### PR TITLE
Don't retrieve quantile unless doing continuous tagging

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -370,44 +370,44 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   //
   // run the btagging decision or get weight and quantile if running continuous
   //
-  for( const xAOD::Jet* jet_itr : *(inJets))
-    {
+  for( const xAOD::Jet* jet_itr : *(inJets)){
 
-      if(!m_useContinuous)
-	{ // get tagging decision
-	  ANA_MSG_DEBUG(" Getting tagging decision ");
+    if(!m_useContinuous){
+      // get tagging decision
+      ANA_MSG_DEBUG(" Getting tagging decision ");
 
-	  // Add decorator for decision
-	  if( m_BJetSelectTool_handle->accept( *jet_itr ) )
-	    dec_isBTag( *jet_itr ) = 1;
-	  else
-	    dec_isBTag( *jet_itr ) = 0;
+      // Add decorator for decision
+      if( m_BJetSelectTool_handle->accept( *jet_itr ) )
+        dec_isBTag( *jet_itr ) = 1;
+      else
+        dec_isBTag( *jet_itr ) = 0;
 
-	  // Add pT-dependent b-tag decision decorator (intended for use in OR)
-	  if ((m_orBJetPtUpperThres < 0 || m_orBJetPtUpperThres > (*jet_itr).pt()/1000.) // passes pT criteria
-	      && m_BJetSelectTool_handle->accept( *jet_itr ) )
-	    dec_isBTagOR( *jet_itr ) = 1;
-	  else
-	    dec_isBTagOR( *jet_itr ) = 0;
-	}
-      if(m_useContinuous || m_alwaysGetTagWeight)
-	{ // continuous b-tagging
-
-	  ANA_MSG_DEBUG(" Getting TaggerWeight and Quantile");
-
-	  double tagWeight;
-	  if( m_BJetSelectTool_handle->getTaggerWeight( *jet_itr, tagWeight)!=CP::CorrectionCode::Ok )
-	    {
-	      ANA_MSG_ERROR(" Error retrieving b-tagger weight ");
-	      return EL::StatusCode::FAILURE;
-	    }
-	  int quantile = m_BJetSelectTool_handle->getQuantile(*jet_itr);
-	  ANA_MSG_DEBUG( "tagWeight: " << tagWeight );
-	  ANA_MSG_DEBUG( "quantile: " << quantile );
-	  dec_Weight( *jet_itr)    = tagWeight;
-	  dec_Quantile( *jet_itr ) = quantile;
-	}
+      // Add pT-dependent b-tag decision decorator (intended for use in OR)
+      if ((m_orBJetPtUpperThres < 0 || m_orBJetPtUpperThres > (*jet_itr).pt()/1000.) // passes pT criteria
+          && m_BJetSelectTool_handle->accept( *jet_itr ) )
+        dec_isBTagOR( *jet_itr ) = 1;
+      else
+        dec_isBTagOR( *jet_itr ) = 0;
     }
+    else{
+      ANA_MSG_DEBUG(" Getting Quantile");
+      int quantile = m_BJetSelectTool_handle->getQuantile(*jet_itr);
+      ANA_MSG_DEBUG( "quantile: " << quantile );
+      dec_Quantile( *jet_itr ) = quantile;
+    }
+    if(m_useContinuous || m_alwaysGetTagWeight){
+
+      ANA_MSG_DEBUG(" Getting TaggerWeight");
+
+      double tagWeight;
+      if( m_BJetSelectTool_handle->getTaggerWeight( *jet_itr, tagWeight)!=CP::CorrectionCode::Ok ){
+        ANA_MSG_ERROR(" Error retrieving b-tagger weight ");
+        return EL::StatusCode::FAILURE;
+      }
+      ANA_MSG_DEBUG( "tagWeight: " << tagWeight );
+      dec_Weight( *jet_itr) = tagWeight;
+    }
+  }
 
   //
   // get the scale factors for all jets

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -46,7 +46,7 @@ public:
   /// @brief BTaggingSelectionTool throws an error on missing tagging weights. If false, a warning is given instead
   bool        m_errorOnTagWeightFailure = true;
   /// @brief Decorate tag weights even if we're not using pseudocontinuous b-tagging
-	bool        m_alwaysGetTagWeight = false;
+  bool        m_alwaysGetTagWeight = false;
 
   // allowed operating points:
   // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingCalibrationDataInterface#xAOD_interface


### PR DESCRIPTION
This is a minor adjustment to #1 so that it no longer attempts to retrieve the b-tagging quantile unless continuous b-tagging is specifically requested. The effect is to remove error messages (which weren't actually problematic if the user doesn't use the quantile info). I've also improved some of the formatting in this section while I was at it.